### PR TITLE
feat(server,agent): trusted_subnet (CIDR); X-Real-IP в агенте; 403 вн…

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -86,6 +86,8 @@ func main() {
 	router := gin.New()
 	router.Use(gin.Recovery())
 	router.Use(middleware.LoggingMiddleware(logger))
+	// Проверка доверенной подсети перед обработкой метрик
+	router.Use(middleware.TrustedSubnetMiddleware(cfg.TrustedSubnet))
 	if cfg.Key != "" {
 		router.Use(middleware.HashRequestMiddleware(cfg.Key))
 		router.Use(middleware.HashResponseMiddleware(cfg.Key))

--- a/internal/app/agent/sender/sender.go
+++ b/internal/app/agent/sender/sender.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -222,6 +223,9 @@ func (s *Sender) Send(metrics map[string]interface{}) {
 		if hashHeader != "" {
 			req.Header.Set("HashSHA256", hashHeader)
 		}
+		if ip := detectRealIP(); ip != "" {
+			req.Header.Set("X-Real-IP", ip)
+		}
 
 		resp, err := s.sendRequestWithRetry(req)
 		if err != nil {
@@ -291,6 +295,9 @@ func (s *Sender) SendBatch(metrics map[string]interface{}) {
 	if hashHeader != "" {
 		req.Header.Set("HashSHA256", hashHeader)
 	}
+	if ip := detectRealIP(); ip != "" {
+		req.Header.Set("X-Real-IP", ip)
+	}
 
 	resp, err := s.sendRequestWithRetry(req)
 	if err != nil {
@@ -298,4 +305,46 @@ func (s *Sender) SendBatch(metrics map[string]interface{}) {
 		return
 	}
 	resp.Body.Close()
+}
+
+// detectRealIP пытается определить локальный IP-адрес хоста агента (не loopback).
+// Возвращает строковое представление или пустую строку, если определить не удалось.
+func detectRealIP() string {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return ""
+	}
+	for _, iface := range ifaces {
+		if (iface.Flags & net.FlagUp) == 0 {
+			continue
+		}
+		if (iface.Flags & net.FlagLoopback) != 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+			if ip == nil {
+				continue
+			}
+			if ip.IsLoopback() {
+				continue
+			}
+			// Предпочтительно IPv4; если IPv6 — возвращаем как есть
+			if ip4 := ip.To4(); ip4 != nil {
+				return ip4.String()
+			}
+			return ip.String()
+		}
+	}
+	return ""
 }

--- a/internal/app/server/config/config.go
+++ b/internal/app/server/config/config.go
@@ -22,6 +22,8 @@ type Config struct {
 	EnableHTTPS bool
 	// Путь к приватному ключу RSA для расшифровки входящих сообщений (CRYPTO_KEY или -crypto-key)
 	CryptoKeyPath string
+	// Доверенная подсеть в формате CIDR; пусто — проверка отключена
+	TrustedSubnet string
 }
 
 // serverJSONConfig описывает формат JSON-конфига для сервера.
@@ -34,8 +36,9 @@ type serverJSONConfig struct {
 	DatabaseDSN   *string `json:"database_dsn"`
 	CryptoKey     *string `json:"crypto_key"`
 	// Дополнительные действующие опции приложения
-	Key         *string `json:"key"`
-	EnableHTTPS *bool   `json:"enable_https"`
+	Key           *string `json:"key"`
+	EnableHTTPS   *bool   `json:"enable_https"`
+	TrustedSubnet *string `json:"trusted_subnet"`
 }
 
 // findConfigPathFromArgs ищет путь к JSON-файлу конфигурации в аргументах командной строки (-c, -config)
@@ -85,6 +88,9 @@ func applyJSONToConfig(cfg *Config, jc serverJSONConfig) {
 	if jc.EnableHTTPS != nil {
 		cfg.EnableHTTPS = *jc.EnableHTTPS
 	}
+	if jc.TrustedSubnet != nil {
+		cfg.TrustedSubnet = *jc.TrustedSubnet
+	}
 	if jc.StoreInterval != nil && *jc.StoreInterval != "" {
 		if d, err := time.ParseDuration(*jc.StoreInterval); err == nil {
 			cfg.StoreInterval = d
@@ -103,6 +109,7 @@ func NewConfig() *Config {
 		Key:             "",
 		EnableHTTPS:     false,
 		CryptoKeyPath:   "",
+		TrustedSubnet:   "",
 	}
 
 	// 1) Предварительно ищем путь к JSON-конфигу в аргументах или окружении
@@ -137,6 +144,8 @@ func NewConfig() *Config {
 	flag.BoolVar(&cfg.EnableHTTPS, "s", cfg.EnableHTTPS, "Enable HTTPS (ListenAndServeTLS)")
 	// Флаг приватного ключа для асимметричного шифрования
 	flag.StringVar(&cfg.CryptoKeyPath, "crypto-key", cfg.CryptoKeyPath, "Path to RSA private key (PEM)")
+	// Флаг доверенной подсети в формате CIDR
+	flag.StringVar(&cfg.TrustedSubnet, "t", cfg.TrustedSubnet, "Trusted subnet in CIDR (e.g. 192.168.1.0/24)")
 	flag.Parse()
 
 	if envAddress := os.Getenv("ADDRESS"); envAddress != "" {
@@ -176,6 +185,10 @@ func NewConfig() *Config {
 
 	if envCryptoKey := os.Getenv("CRYPTO_KEY"); envCryptoKey != "" {
 		cfg.CryptoKeyPath = envCryptoKey
+	}
+
+	if envTrusted := os.Getenv("TRUSTED_SUBNET"); envTrusted != "" {
+		cfg.TrustedSubnet = envTrusted
 	}
 
 	return cfg

--- a/internal/app/server/middleware/trusted_subnet.go
+++ b/internal/app/server/middleware/trusted_subnet.go
@@ -1,0 +1,57 @@
+package middleware
+
+import (
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// TrustedSubnetMiddleware проверяет, что X-Real-IP клиента входит в доверенную подсеть CIDR
+// Проверка применяется только к запросам отправки метрик: POST /update..., POST /updates...
+// При пустом cidr проверка отключена.
+func TrustedSubnetMiddleware(cidr string) gin.HandlerFunc {
+	var ipnet *net.IPNet
+	if cidr != "" {
+		if _, n, err := net.ParseCIDR(strings.TrimSpace(cidr)); err == nil {
+			ipnet = n
+		}
+	}
+
+	return func(c *gin.Context) {
+		// Если проверка отключена — пропускаем
+		if ipnet == nil {
+			c.Next()
+			return
+		}
+
+		// Применяем только к POST /update* и POST /updates*
+		if c.Request.Method != http.MethodPost {
+			c.Next()
+			return
+		}
+		path := c.Request.URL.Path
+		if !(strings.HasPrefix(path, "/update") || strings.HasPrefix(path, "/updates")) {
+			c.Next()
+			return
+		}
+
+		ipStr := strings.TrimSpace(c.Request.Header.Get("X-Real-IP"))
+		if ipStr == "" {
+			c.AbortWithStatus(http.StatusForbidden)
+			return
+		}
+		ip := net.ParseIP(ipStr)
+		if ip == nil {
+			c.AbortWithStatus(http.StatusForbidden)
+			return
+		}
+		if !ipnet.Contains(ip) {
+			c.AbortWithStatus(http.StatusForbidden)
+			return
+		}
+
+		c.Next()
+	}
+}


### PR DESCRIPTION
Задание по треку «Сервис сбора метрик и алертинга»
Добавьте в конфигурационный JSON-файл сервера поле trusted_subnet (тип string, переменная окружения TRUSTED_SUBNET, флаг -t), в которое можно передать строковое представление бесклассовой адресации (CIDR).
Добавьте в запрос агента заголовок X-Real-IP, в котором должен содержаться IP-адрес хоста агента.
При отправке метрик агентом серверу нужно проверять, что переданный в заголовке запроса X-Real-IP IP-адрес агента входит в доверенную подсеть, в противном случае возвращать статус ответа 403 Forbidden.
При пустом значении переменной trusted_subnet метрики должны обрабатываться сервером без дополнительных ограничений.